### PR TITLE
feat: wait a full feedback update to write it

### DIFF
--- a/bms_victron_smart_shunt.orogen
+++ b/bms_victron_smart_shunt.orogen
@@ -22,8 +22,6 @@ task_context "Task", subclasses: "iodrivers_base::Task" do
     output_port "smart_shunt_feedback", "bms_victron_smart_shunt::SmartShuntFeedback"
     # The battery status, if present
     output_port "battery_status", "/power_base/BatteryStatus"
-    # The DC source status, if present
-    output_port "dc_source_status", "/power_base/DCSourceStatus"
 
     fd_driven
 end

--- a/bms_victron_smart_shunt.orogen
+++ b/bms_victron_smart_shunt.orogen
@@ -16,7 +16,7 @@ task_context "Task", subclasses: "iodrivers_base::Task" do
     needs_configuration
 
     # The number of packets needed to compose a full feedback update
-    property "needed_packets", "int", 2
+    property "packets_to_compose_a_full_feedback", "int", 2
 
     # The complete Victron Smart Shunt feedback
     output_port "smart_shunt_feedback", "bms_victron_smart_shunt::SmartShuntFeedback"

--- a/bms_victron_smart_shunt.orogen
+++ b/bms_victron_smart_shunt.orogen
@@ -15,6 +15,9 @@ import_types_from "power_base"
 task_context "Task", subclasses: "iodrivers_base::Task" do
     needs_configuration
 
+    # The number of packets needed to compose a full feedback update
+    property "needed_packets", "int", 2
+
     # The complete Victron Smart Shunt feedback
     output_port "smart_shunt_feedback", "bms_victron_smart_shunt::SmartShuntFeedback"
     # The battery status, if present

--- a/bms_victron_smart_shunt.orogen
+++ b/bms_victron_smart_shunt.orogen
@@ -10,11 +10,17 @@ import_types_from "std"
 import_types_from "base"
 import_types_from "iodrivers_base"
 import_types_from "bms_victron_smart_shunt/SmartShuntFeedback.hpp"
+import_types_from "power_base"
 
 task_context "Task", subclasses: "iodrivers_base::Task" do
     needs_configuration
 
+    # The complete Victron Smart Shunt feedback
     output_port "smart_shunt_feedback", "bms_victron_smart_shunt::SmartShuntFeedback"
+    # The battery status, if present
+    output_port "battery_status", "/power_base/BatteryStatus"
+    # The DC source status, if present
+    output_port "dc_source_status", "/power_base/DCSourceStatus"
 
     fd_driven
 end

--- a/manifest.xml
+++ b/manifest.xml
@@ -10,4 +10,5 @@
   <depend package="drivers/bms_victron_smart_shunt" />
   <depend package="base/orogen/types" />
   <depend package="drivers/orogen/iodrivers_base" />
+  <depend package="drivers/orogen/power_base" />
 </package>

--- a/tasks/Task.cpp
+++ b/tasks/Task.cpp
@@ -28,7 +28,7 @@ bool bms_victron_smart_shunt::Task::configureHook()
     if (!TaskBase::configureHook())
         return false;
     guard.commit();
-    m_needed_packets = _needed_packets.get();
+    m_packets_to_compose_a_full_feedback = _packets_to_compose_a_full_feedback.get();
     m_max_current = 0;
     return true;
 }
@@ -78,9 +78,10 @@ void bms_victron_smart_shunt::Task::updateMaxCurrent(double actual_current)
 void bms_victron_smart_shunt::Task::processIO()
 {
     Driver* driver = static_cast<bms_victron_smart_shunt::Driver*>(mDriver);
-    SmartShuntFeedback feedback = driver->processOne(m_needed_packets);
+    SmartShuntFeedback feedback =
+        driver->processOne(m_packets_to_compose_a_full_feedback);
     updateMaxCurrent(feedback.current);
-    if (driver->packetsCounter() >= 2) {
+    if (driver->packetsCounter() >= m_packets_to_compose_a_full_feedback) {
         _smart_shunt_feedback.write(feedback);
         _battery_status.write(toBatteryStatus(feedback, m_max_current));
     }

--- a/tasks/Task.cpp
+++ b/tasks/Task.cpp
@@ -25,10 +25,6 @@ bool bms_victron_smart_shunt::Task::configureHook()
     setDriver(driver);
     if (!TaskBase::configureHook())
         return false;
-    // Do device initialization here. NEVER before
-    // TaskBase::configureHook has been called
-    // Also, don't forget to release the guard by
-    // calling commit() on it just before returning.
     guard.commit();
     return true;
 }
@@ -36,7 +32,6 @@ bool bms_victron_smart_shunt::Task::startHook()
 {
     if (!TaskBase::startHook())
         return false;
-    Driver* driver = static_cast<bms_victron_smart_shunt::Driver*>(mDriver);
     return true;
 }
 void bms_victron_smart_shunt::Task::updateHook()
@@ -59,6 +54,8 @@ void bms_victron_smart_shunt::Task::cleanupHook()
 void bms_victron_smart_shunt::Task::processIO()
 {
     Driver* driver = static_cast<bms_victron_smart_shunt::Driver*>(mDriver);
-    bms_victron_smart_shunt::SmartShuntFeedback feedback = driver->processOne();
-    _smart_shunt_feedback.write(feedback);
+    SmartShuntFeedback feedback = driver->processOne();
+    if (driver->packetsCounter() >= 2) {
+        _smart_shunt_feedback.write(feedback);
+    }
 }

--- a/tasks/Task.cpp
+++ b/tasks/Task.cpp
@@ -3,9 +3,11 @@
 #include "Task.hpp"
 #include <bms_victron_smart_shunt/Driver.hpp>
 #include <iodrivers_base/ConfigureGuard.hpp>
+#include <power_base/ACSourceStatus.hpp>
 
 using namespace bms_victron_smart_shunt;
 using namespace iodrivers_base;
+using namespace power_base;
 
 bms_victron_smart_shunt::Task::Task(std::string const& name)
     : TaskBase(name)
@@ -51,11 +53,48 @@ void bms_victron_smart_shunt::Task::cleanupHook()
     TaskBase::cleanupHook();
 }
 
+static BatteryStatus toBatteryStatus(SmartShuntFeedback const& feedback,
+    double max_current)
+{
+    BatteryStatus battery_status;
+    battery_status.time = feedback.timestamp;
+    battery_status.temperature = feedback.temperature;
+    battery_status.charge = feedback.state_of_charge;
+    battery_status.current = feedback.current;
+    battery_status.voltage = feedback.voltage;
+    battery_status.max_current = max_current;
+    return battery_status;
+}
+
+static DCSourceStatus toDCSourceStatus(SmartShuntFeedback const& feedback,
+    double max_current)
+{
+    DCSourceStatus dc_source_status;
+    dc_source_status.time = feedback.timestamp;
+    dc_source_status.voltage = feedback.voltage;
+    dc_source_status.current = feedback.current;
+    dc_source_status.max_current = max_current;
+    return dc_source_status;
+}
+
+void bms_victron_smart_shunt::Task::updateMaxCurrent(double actual_current)
+{
+    if (fabs(actual_current) > fabs(m_max_current)) {
+        m_max_current = actual_current;
+    }
+}
+
 void bms_victron_smart_shunt::Task::processIO()
 {
     Driver* driver = static_cast<bms_victron_smart_shunt::Driver*>(mDriver);
     SmartShuntFeedback feedback = driver->processOne();
     if (driver->packetsCounter() >= 2) {
         _smart_shunt_feedback.write(feedback);
+        if (feedback.dc_monitor_mode = DCMonitorMode(BATTERY_MONITOR)) {
+            _battery_status.write(toBatteryStatus(feedback, m_max_current));
+        }
+        if (feedback.dc_monitor_mode = DCMonitorMode(DC_SYSTEM)) {
+            _dc_source_status.write(toDCSourceStatus(feedback, m_max_current));
+        }
     }
 }

--- a/tasks/Task.cpp
+++ b/tasks/Task.cpp
@@ -28,6 +28,7 @@ bool bms_victron_smart_shunt::Task::configureHook()
     if (!TaskBase::configureHook())
         return false;
     guard.commit();
+    m_needed_packets = _needed_packets.get();
     return true;
 }
 bool bms_victron_smart_shunt::Task::startHook()
@@ -87,13 +88,13 @@ void bms_victron_smart_shunt::Task::updateMaxCurrent(double actual_current)
 void bms_victron_smart_shunt::Task::processIO()
 {
     Driver* driver = static_cast<bms_victron_smart_shunt::Driver*>(mDriver);
-    SmartShuntFeedback feedback = driver->processOne();
+    SmartShuntFeedback feedback = driver->processOne(m_needed_packets);
     if (driver->packetsCounter() >= 2) {
         _smart_shunt_feedback.write(feedback);
-        if (feedback.dc_monitor_mode = DCMonitorMode(BATTERY_MONITOR)) {
+        if (feedback.dc_monitor_mode == DCMonitorMode(BATTERY_MONITOR)) {
             _battery_status.write(toBatteryStatus(feedback, m_max_current));
         }
-        if (feedback.dc_monitor_mode = DCMonitorMode(DC_SYSTEM)) {
+        if (feedback.dc_monitor_mode == DCMonitorMode(DC_SYSTEM)) {
             _dc_source_status.write(toDCSourceStatus(feedback, m_max_current));
         }
     }

--- a/tasks/Task.cpp
+++ b/tasks/Task.cpp
@@ -60,7 +60,7 @@ static BatteryStatus toBatteryStatus(SmartShuntFeedback const& feedback,
     BatteryStatus battery_status;
     battery_status.time = feedback.timestamp;
     battery_status.temperature = feedback.temperature;
-    battery_status.charge = feedback.state_of_charge;
+    battery_status.charge = feedback.state_of_charge / 100;
     battery_status.current = feedback.current;
     battery_status.voltage = feedback.voltage;
     battery_status.max_current = max_current;

--- a/tasks/Task.cpp
+++ b/tasks/Task.cpp
@@ -29,6 +29,7 @@ bool bms_victron_smart_shunt::Task::configureHook()
         return false;
     guard.commit();
     m_needed_packets = _needed_packets.get();
+    m_max_current = 0;
     return true;
 }
 bool bms_victron_smart_shunt::Task::startHook()
@@ -67,20 +68,9 @@ static BatteryStatus toBatteryStatus(SmartShuntFeedback const& feedback,
     return battery_status;
 }
 
-static DCSourceStatus toDCSourceStatus(SmartShuntFeedback const& feedback,
-    double max_current)
-{
-    DCSourceStatus dc_source_status;
-    dc_source_status.time = feedback.timestamp;
-    dc_source_status.voltage = feedback.voltage;
-    dc_source_status.current = feedback.current;
-    dc_source_status.max_current = max_current;
-    return dc_source_status;
-}
-
 void bms_victron_smart_shunt::Task::updateMaxCurrent(double actual_current)
 {
-    if (fabs(actual_current) > fabs(m_max_current)) {
+    if (actual_current > m_max_current) {
         m_max_current = actual_current;
     }
 }
@@ -89,13 +79,9 @@ void bms_victron_smart_shunt::Task::processIO()
 {
     Driver* driver = static_cast<bms_victron_smart_shunt::Driver*>(mDriver);
     SmartShuntFeedback feedback = driver->processOne(m_needed_packets);
+    updateMaxCurrent(feedback.current);
     if (driver->packetsCounter() >= 2) {
         _smart_shunt_feedback.write(feedback);
-        if (feedback.dc_monitor_mode == DCMonitorMode(BATTERY_MONITOR)) {
-            _battery_status.write(toBatteryStatus(feedback, m_max_current));
-        }
-        if (feedback.dc_monitor_mode == DCMonitorMode(DC_SYSTEM)) {
-            _dc_source_status.write(toDCSourceStatus(feedback, m_max_current));
-        }
+        _battery_status.write(toBatteryStatus(feedback, m_max_current));
     }
 }

--- a/tasks/Task.hpp
+++ b/tasks/Task.hpp
@@ -34,7 +34,7 @@ namespace bms_victron_smart_shunt {
          * @brief The maximum registred current
          *
          */
-        double m_max_current = base::unknown<double>();
+        double m_max_current = 0;
         /**
          * @brief The number of needed packets to compose a full update
          * 

--- a/tasks/Task.hpp
+++ b/tasks/Task.hpp
@@ -3,6 +3,7 @@
 #ifndef BMS_VICTRON_SMART_SHUNT_TASK_TASK_HPP
 #define BMS_VICTRON_SMART_SHUNT_TASK_TASK_HPP
 
+#include "base/Float.hpp"
 #include "bms_victron_smart_shunt/TaskBase.hpp"
 
 namespace bms_victron_smart_shunt {
@@ -29,6 +30,18 @@ namespace bms_victron_smart_shunt {
         friend class TaskBase;
 
     protected:
+        /**
+         * @brief The maximum registred current
+         *
+         */
+        double m_max_current = base::unknown<double>();
+        /**
+         * @brief Updates the maximum registred current
+         * 
+         * @param actual_current 
+         */
+        void updateMaxCurrent(double actual_current);
+
     public:
         /** TaskContext constructor for Task
          * \param name Name of the task. This name needs to be unique to make it

--- a/tasks/Task.hpp
+++ b/tasks/Task.hpp
@@ -36,6 +36,11 @@ namespace bms_victron_smart_shunt {
          */
         double m_max_current = base::unknown<double>();
         /**
+         * @brief The number of needed packets to compose a full update
+         * 
+         */
+        int m_needed_packets = 2;
+        /**
          * @brief Updates the maximum registred current
          * 
          * @param actual_current 

--- a/tasks/Task.hpp
+++ b/tasks/Task.hpp
@@ -37,13 +37,13 @@ namespace bms_victron_smart_shunt {
         double m_max_current = 0;
         /**
          * @brief The number of needed packets to compose a full update
-         * 
+         *
          */
-        int m_needed_packets = 2;
+        int m_packets_to_compose_a_full_feedback = 2;
         /**
          * @brief Updates the maximum registred current
-         * 
-         * @param actual_current 
+         *
+         * @param actual_current
          */
         void updateMaxCurrent(double actual_current);
 


### PR DESCRIPTION
Depends on:
- [ ] https://github.com/tidewise/drivers-bms_victron_smart_shunt/pull/2/

On top of: #1 

# What is this PR for
Write data struct only when it has a full update.
The device sends the data divided in two packets, so it's necessary to merge the data to compose the feedback struct.

# Results, How I tested
BATTERY STATUS
![image](https://github.com/user-attachments/assets/28c64e51-70b3-4bdc-a94f-45a7850b6deb)

MERGE
https://github.com/user-attachments/assets/cc8fffbd-dee3-4651-b350-15759e01c15b


# Checklist
- [x] Assign yourself  in the PR
