### PR TITLE
fix: value reported in the DC status max_current field

### DIFF
--- a/bms_victron_smart_shunt.orogen
+++ b/bms_victron_smart_shunt.orogen
@@ -17,6 +17,8 @@ task_context "Task", subclasses: "iodrivers_base::Task" do
 
     # The number of packets needed to compose a full feedback update
     property "packets_to_compose_a_full_feedback", "int", 2
+    # Maximum current that can safely be output by the batteries this BMS is monitoring
+    property "max_current", "double", 0
 
     # The complete Victron Smart Shunt feedback
     output_port "smart_shunt_feedback", "bms_victron_smart_shunt::SmartShuntFeedback"

--- a/tasks/Task.cpp
+++ b/tasks/Task.cpp
@@ -29,7 +29,6 @@ bool bms_victron_smart_shunt::Task::configureHook()
         return false;
     guard.commit();
     m_packets_to_compose_a_full_feedback = _packets_to_compose_a_full_feedback.get();
-    m_max_current = 0;
     return true;
 }
 bool bms_victron_smart_shunt::Task::startHook()
@@ -68,21 +67,13 @@ static BatteryStatus toBatteryStatus(SmartShuntFeedback const& feedback,
     return battery_status;
 }
 
-void bms_victron_smart_shunt::Task::updateMaxCurrent(double actual_current)
-{
-    if (actual_current > m_max_current) {
-        m_max_current = actual_current;
-    }
-}
-
 void bms_victron_smart_shunt::Task::processIO()
 {
     Driver* driver = static_cast<bms_victron_smart_shunt::Driver*>(mDriver);
     SmartShuntFeedback feedback =
         driver->processOne(m_packets_to_compose_a_full_feedback);
-    updateMaxCurrent(feedback.current);
     if (driver->packetsCounter() >= m_packets_to_compose_a_full_feedback) {
         _smart_shunt_feedback.write(feedback);
-        _battery_status.write(toBatteryStatus(feedback, m_max_current));
+        _battery_status.write(toBatteryStatus(feedback, _max_current.get()));
     }
 }

--- a/tasks/Task.hpp
+++ b/tasks/Task.hpp
@@ -31,21 +31,10 @@ namespace bms_victron_smart_shunt {
 
     protected:
         /**
-         * @brief The maximum registred current
-         *
-         */
-        double m_max_current = 0;
-        /**
          * @brief The number of needed packets to compose a full update
          *
          */
         int m_packets_to_compose_a_full_feedback = 2;
-        /**
-         * @brief Updates the maximum registred current
-         *
-         * @param actual_current
-         */
-        void updateMaxCurrent(double actual_current);
 
     public:
         /** TaskContext constructor for Task


### PR DESCRIPTION
As the DCSourceStatus documentation states, max_current is

  Maximum current this source can provide (in A)
