### PR TITLE
fix: update feedback structure upon every packet arrival

### DIFF
--- a/bms_victron_smart_shunt.orogen
+++ b/bms_victron_smart_shunt.orogen
@@ -15,8 +15,6 @@ import_types_from "power_base"
 task_context "Task", subclasses: "iodrivers_base::Task" do
     needs_configuration
 
-    # The number of packets needed to compose a full feedback update
-    property "packets_to_compose_a_full_feedback", "int", 2
     # Maximum current that can safely be output by the batteries this BMS is monitoring
     property "max_current", "double", 0
 

--- a/tasks/Task.cpp
+++ b/tasks/Task.cpp
@@ -28,7 +28,6 @@ bool bms_victron_smart_shunt::Task::configureHook()
     if (!TaskBase::configureHook())
         return false;
     guard.commit();
-    m_packets_to_compose_a_full_feedback = _packets_to_compose_a_full_feedback.get();
     return true;
 }
 bool bms_victron_smart_shunt::Task::startHook()
@@ -70,10 +69,7 @@ static BatteryStatus toBatteryStatus(SmartShuntFeedback const& feedback,
 void bms_victron_smart_shunt::Task::processIO()
 {
     Driver* driver = static_cast<bms_victron_smart_shunt::Driver*>(mDriver);
-    SmartShuntFeedback feedback =
-        driver->processOne(m_packets_to_compose_a_full_feedback);
-    if (driver->packetsCounter() >= m_packets_to_compose_a_full_feedback) {
-        _smart_shunt_feedback.write(feedback);
-        _battery_status.write(toBatteryStatus(feedback, _max_current.get()));
-    }
+    SmartShuntFeedback feedback = driver->processOne();
+    _smart_shunt_feedback.write(feedback);
+    _battery_status.write(toBatteryStatus(feedback, _max_current.get()));
 }

--- a/tasks/Task.hpp
+++ b/tasks/Task.hpp
@@ -30,12 +30,6 @@ namespace bms_victron_smart_shunt {
         friend class TaskBase;
 
     protected:
-        /**
-         * @brief The number of needed packets to compose a full update
-         *
-         */
-        int m_packets_to_compose_a_full_feedback = 2;
-
     public:
         /** TaskContext constructor for Task
          * \param name Name of the task. This name needs to be unique to make it


### PR DESCRIPTION
Depends on:
- [ ] https://github.com/tidewise/drivers-bms_victron_smart_shunt/pull/3
- [ ] https://github.com/tidewise/bundles-lars/pull/154

# What is this PR for
update feedback structure upon every packet arrival
[sc-58933]

The number of necessary packet to compose a full feedback is unknown.
There is no information in the user manual and looks like the way that the device sends the info at the packets is not consistent.
So we decided to update the feedback upon every packet arrival.

https://github.com/user-attachments/assets/a8827697-9c66-4d05-b60c-180f48b4eca2


# Checklist
- [x] Assign yourself  in the PR
